### PR TITLE
Windows Permissions

### DIFF
--- a/tarhelper/tar.go
+++ b/tarhelper/tar.go
@@ -336,6 +336,9 @@ func (t *Tar) processEntry(fullName string, f os.FileInfo, dirStack []string) er
 			header.Mode = 0644
 		}
 
+		// Necessary to ensure files from Windows have +x bit written.
+		header.Mode = int64(chmodTarEntry(mode))
+
 		// check to see if this is a hard link
 		if linkCountForFileInfo(f) > 1 {
 			inode := inodeForFileInfo(f)

--- a/tarhelper/utils_posixfs.go
+++ b/tarhelper/utils_posixfs.go
@@ -39,3 +39,9 @@ func linkCountForFileInfo(fi os.FileInfo) uint {
 func inodeForFileInfo(fi os.FileInfo) uint64 {
 	return fi.Sys().(*syscall.Stat_t).Ino
 }
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	return perm // noop for posixfs as golang APIs provide perm bits correctly
+}

--- a/tarhelper/utils_windows.go
+++ b/tarhelper/utils_windows.go
@@ -50,3 +50,12 @@ func inodeForFileInfo(_ os.FileInfo) uint64 {
 	// provide real data here
 	return 1
 }
+
+// chmodTarEntry is used to adjust the file permissions used in tar header based
+// on the platform the archival is done.
+func chmodTarEntry(perm os.FileMode) os.FileMode {
+	// Add the x bit: make everything +x from windows
+	perm |= 0111
+
+	return perm
+}


### PR DESCRIPTION
Windows does not support the idea of an 'executable' bit on permissions.
As a result, no file tar'd on Windows would be executable causing many apps
to fail.  This included simple demo ruby/bash apps.  This fix just causes
everything tar'd on a Windows machine to be marked as executable.

Ideally the fix would be a little more fine grained, but this seems to be
the only way to ensure that all files needed as +x are marked as such.  In
Windows, its almost as if all files are executable so this seems to be in
line with their approach.

Docker's Window CLI faced this same concern and so our code fix and approach
mirror theirs.  See https://github.com/docker/docker/issues/11047