### PR TITLE
Fix handling of umask around chmod operations.

### DIFF
--- a/tarhelper/utils_posixfs.go
+++ b/tarhelper/utils_posixfs.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 )
 
-func osUmask(mask int) {
-	syscall.Umask(mask)
+func osUmask(mask int) int {
+	return syscall.Umask(mask)
 }
 
 func osMknod(name string, mode uint32, dev int) error {

--- a/tarhelper/utils_windows.go
+++ b/tarhelper/utils_windows.go
@@ -21,8 +21,9 @@ func minordev(dev int64) int64 {
 	panic(fmt.Sprintf("no Windows support for making Unix devices [minordev(%d)]", dev))
 }
 
-func osUmask(mask int) {
+func osUmask(mask int) int {
 	// noop
+	return 0
 }
 
 func osMknod(name string, mode uint32, dev int) error {


### PR DESCRIPTION
This updates the wrappers for Windows compatibility on umask to return the old
umask.

This updates the mknod handling, which already was doing umask(0) to ensure it
resets the umask back after it is done.

This also updates the chmod and create operations operations done to regular
files/directories to be wrapped in a umask(0) operation and ensure the umask
is reset after the chmod.

The handling does not reset with a defer to ensure the umask is reset
immediately before any other file operations might be done.

@tcahill @olegshaldybin 