### PR TITLE
Improves handling when Tar is pointed directly at a file.

### DIFF
--- a/tarhelper/tar.go
+++ b/tarhelper/tar.go
@@ -143,14 +143,23 @@ func (t *Tar) Archive() error {
 		return fmt.Errorf("unknown compression type: %v", t.Compression)
 	}
 
-	// ensure we write the current directory
+	// ensure the target exists
 	f, err := os.Stat(t.target)
 	if err != nil {
 		return err
 	}
 
+	// If the target is a file rather than a directory, adjust our initial entry
+	// name and target. It will still get just that directory, but want to ensure
+	// we don't tar a file named "."
+	startFullName := "."
+	if !f.IsDir() {
+		t.target = filepath.Dir(t.target)
+		startFullName = filepath.Join(".", f.Name())
+	}
+
 	// walk the directory tree
-	if err := t.processEntry(".", f, []string{}); err != nil {
+	if err := t.processEntry(startFullName, f, []string{}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This addresses a bug (#ENGT-1779) where an invalid tarball was created when
tarhelper.NewTar is pointed directly at a file rather than a directory.
Previously, it would create a tarball with the file just fine, but the file in
the tarball would be named ".".

When then untaring the file, it would simply not work too well. If the
NewUntar path already existed, it would error, or if it didn't exist, create
the target but the caller is often expecting a path, while it would create it
as a file.

This change improves the handling, where when it is pointed at a file, it will
tar just the file, but preserve its filename as the entry, and when the same
file is untarred, the target would be a path and it would contain the
specified file.

@alextoombs @klobucar 