### PR TITLE
Move away from setting umask at all and use explicit chmod.

### DIFF
--- a/tarhelper/utils_posixfs.go
+++ b/tarhelper/utils_posixfs.go
@@ -9,10 +9,6 @@ import (
 	"syscall"
 )
 
-func osUmask(mask int) int {
-	return syscall.Umask(mask)
-}
-
 func osMknod(name string, mode uint32, dev int) error {
 	return syscall.Mknod(name, mode, dev)
 }

--- a/tarhelper/utils_windows.go
+++ b/tarhelper/utils_windows.go
@@ -21,11 +21,6 @@ func minordev(dev int64) int64 {
 	panic(fmt.Sprintf("no Windows support for making Unix devices [minordev(%d)]", dev))
 }
 
-func osUmask(mask int) int {
-	// noop
-	return 0
-}
-
 func osMknod(name string, mode uint32, dev int) error {
 	return fmt.Errorf("no Windows support to mknod(%q) (mode %d dev %d)", name, mode, dev)
 }


### PR DESCRIPTION
This changes places that relied upon setting the umask to instead use an
explicit chmod. This is more explicit and saver, as it avoids altering the
process wide umask which may not be safe with multiple goroutines.

@olegshaldybin @tcahill @philpennock 