### PR TITLE
Return -1 on error from client.Do instead of status code.

### DIFF
--- a/docker/registry.go
+++ b/docker/registry.go
@@ -74,7 +74,7 @@ func GetImage(name, registryURL string) (*Image, int, error) {
 
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, res.StatusCode, err
+		return nil, -1, err
 	}
 	defer res.Body.Close()
 	switch res.StatusCode {


### PR DESCRIPTION
@emil2k @alextoombs facepalm.