### PR TITLE
Add some terminal handling for Windows

### DIFF
--- a/terminal/terminal_state_windows.go
+++ b/terminal/terminal_state_windows.go
@@ -2,25 +2,53 @@
 
 // +build windows
 
-// FIXME: we should implement real terminal state save/restore for Windows
-
 package terminal
 
-type WindowsTerminalState struct{}
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
 
-func Isatty(_ uintptr) bool {
-	//FIXME(Sha): Assume we're not piping output on windows.   This is possible though, and should be handled.
+// Windows terminal code adapted from golang.org/x/crypto/ssh/terminal
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode = kernel32.NewProc("SetConsoleMode")
+)
+
+type WindowsTerminalState struct {
+	mode uint32
+}
+
+func Isatty(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+func getOSTerminalState() (*WindowsTerminalState, error) {
+	fd := uintptr(os.Stdout.Fd())
+	var st uint32
+	_, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	if e != 0 {
+		return nil, error(e)
+	}
+	return &WindowsTerminalState{st}, nil
+}
+
+func (wts *WindowsTerminalState) IsValid() bool {
+	if wts == nil {
+		return false
+	}
 	return true
 }
 
-func getOSTerminalState() (WindowsTerminalState, error) {
-	return WindowsTerminalState{}, nil
-}
-
-func (_ WindowsTerminalState) IsValid() bool {
-	return true
-}
-
-func (_ WindowsTerminalState) Restore() {
+func (wts *WindowsTerminalState) Restore() {
+	if !wts.IsValid() {
+		return
+	}
+	_, _, _ = syscall.Syscall(procSetConsoleMode.Addr(), 2, uintptr(os.Stdout.Fd()), uintptr(wts.mode), 0)
 	return
 }


### PR DESCRIPTION
This addresses some of the needs of terminal handling on Windows.  Most importantly for now, Isatty works as intended.

Adapted from golang.org/x/crypto/ssh/terminal