### PR TITLE
Add a package to render TaskEvents from the Task API Framework.

### DIFF
--- a/taskrenderer/renderer.go
+++ b/taskrenderer/renderer.go
@@ -1,0 +1,73 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package taskrenderer
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// Renderer holds all of the state necessary to gather and output TaskEvents.
+type Renderer struct {
+	out io.Writer
+	err io.Writer
+
+	eventCh chan *TaskEvent
+
+	options *FormatOptions
+}
+
+// FormatOptions provides a way to customize the output of TaskEvents.
+type FormatOptions struct {
+	showTime bool
+}
+
+// New instantiates and returns a new Renderer object.
+func New(out io.Writer, err io.Writer, showTime bool) *Renderer {
+	return &Renderer{
+		out: out,
+		err: err,
+		options: &FormatOptions{
+			showTime: showTime,
+		},
+	}
+}
+
+// RenderEvents reads every event sent on the given channel and renders it.
+// The channel can be closed by the caller at any time to stop rendering.
+func (r *Renderer) RenderEvents(eventCh chan *TaskEvent) {
+	for event := range eventCh {
+		r.renderEvent(event)
+	}
+}
+
+// renderEvent varies output depending on the information provided
+// by the current taskEvent.
+func (r *Renderer) renderEvent(event *TaskEvent) {
+	s := ""
+
+	if r.options.showTime {
+		s += fmt.Sprintf("(%s) ", time.Unix(0, event.Time).Format(time.UnixDate))
+	}
+
+	if event.Thread != "" {
+		s += fmt.Sprintf("[%s] -- ", event.Thread)
+	}
+
+	s += fmt.Sprintf("%s -- ", event.Stage)
+
+	if event.Subtask.Total != 1 {
+		s += fmt.Sprintf("(%d/%d): ", event.Subtask.Index, event.Subtask.Total)
+	}
+
+	s += fmt.Sprintf("%s", event.Subtask.Name)
+
+	if event.Subtask.Progress.Total != 0 {
+		s += fmt.Sprintf(" ... %d%%",
+			(event.Subtask.Progress.Current/event.Subtask.Progress.Total)*100,
+		)
+	}
+
+	fmt.Fprintf(r.out, "%s\n", s)
+}

--- a/taskrenderer/taskevent.go
+++ b/taskrenderer/taskevent.go
@@ -1,0 +1,71 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package taskrenderer
+
+// A TaskEvent carries structured information about events that occur during
+// processing. This information will be persisted, and then forwarded to
+// clients. The structure allows for the client to render TaskEvents in
+// a predictable manner.
+type TaskEvent struct {
+	// TaskUUID is the UUID of the Task that stores this event.
+	// This may be redundant and removable.
+	TaskUUID string `json:"task_uuid"`
+
+	// Type is the type of message this TaskEvent carries.
+	// Can be a plain TASK_EVENT, TASK_EVENT_CLIENT_ERROR,
+	// TASK_EVENT_SERVER_ERROR, TASK_EVENT_CANCEL, or TASK_EVENT_EOS.
+	Type string `json:"task_event_type"`
+
+	// Time will preferably be in unix nanosecond time, and should be the time
+	// immediately before the TaskEvent gets announced on NATS
+	// for persistence, this way the order of TaskEvents can
+	// be reconstructed regardless of latency between components.
+	Time int64 `json:"time"`
+
+	// Thread represents a logically independent procedure within
+	// a Task. For instance, a thread could be "job1" or "job2"
+	// or "Link job1 and job2".
+	Thread string `json:"thread"`
+
+	// Stage indicates a logical grouping of subtasks.
+	// In Continuum, a stage could be "Creating Job",
+	// or "Downloading Packages".
+	Stage string `json:"stage"`
+
+	// Subtask provides a description of the subtask that
+	// this TaskEvent describes.
+	Subtask Subtask `json:"subtask"`
+
+	// Tags provide a hint as to what is being tracked.
+	Tags []string `json:"tags"`
+
+	// Payload is extra information about this TaskEvent.
+	Payload map[string]interface{} `json:"payload"`
+}
+
+// Subtask is any discrete piece of work belonging to a stage.
+// A stage "Creating Package" could contain subtasks of
+// "Checking for Package Existence", "Creating Package", and
+// "Uploading Tarball".
+type Subtask struct {
+	// Name is the human-readable description of this subtask.
+	Name string `json:"name"`
+
+	// Index is the index of this subtask among all subtasks.
+	Index int `json:"index"`
+
+	// Total is the total number of subtasks in the current stage.
+	Total int `json:"total"`
+
+	// Progress indicates how far along this unit of work is.
+	Progress Progress `json:"progress"`
+}
+
+// Progress indicates how far along in processing the current subtask is.
+type Progress struct {
+	// Current is the current progress.
+	Current uint64 `json:"current"`
+
+	// Total is the total amount of work to be done.
+	Total uint64 `json:"total"`
+}


### PR DESCRIPTION
This renderer acts as a simple append-only logger. The main idea
is that the renderer formats incoming TaskEvents in a human-readable
way. TaskEvents will be provided to the renderer via a channel, and
the renderer will output them to the specified io.Writer.