### PR TITLE
Fixed untar on the Windows platform

### DIFF
--- a/tarhelper/untar_test.go
+++ b/tarhelper/untar_test.go
@@ -30,7 +30,7 @@ func TestUntarResolveDestinations(t *testing.T) {
 	runTest := func(p, e string) {
 		dst, err := u.resolveDestination(p)
 		TestExpectSuccess(t, err)
-		TestEqual(t, e, dst)
+		TestEqual(t, dst, e)
 	}
 
 	runTest("a", "a")


### PR DESCRIPTION
The untar package had some paths that were specific to Unix, added some
logic to create them differently depending on the platform.

Also, the chmod function does not work on Windows, added a helper called
`chmod` which is a noop on Windows.

@apcera/cloud-services 