### PR TITLE
Added tempfile package for a file that deletes itself on close.

### DIFF
--- a/tempfile/tempfile.go
+++ b/tempfile/tempfile.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package tempfile
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type ReadSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+type unlinkOnCloseFile struct {
+	*os.File
+}
+
+func (f *unlinkOnCloseFile) Close() error {
+	cerr := f.File.Close()
+	rerr := os.Remove(f.Name())
+	if cerr != nil {
+		return cerr
+	}
+	return rerr
+}
+
+// New will take in a io.Reader and write its content to a new temporary
+// file. The temporary file will be automatically removed when it closed.
+func New(r io.Reader) (ReadSeekCloser, error) {
+	tf, err := ioutil.TempFile(os.TempDir(), "temporary-file")
+	if err != nil {
+		return nil, err
+	}
+
+	f := &unlinkOnCloseFile{tf}
+	successful := false
+	defer func() {
+		if !successful {
+			f.Close()
+		}
+	}()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return nil, err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return nil, err
+	}
+	successful = true
+	return f, nil
+}

--- a/tempfile/tempfile_test.go
+++ b/tempfile/tempfile_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Apcera Inc. All rights reserved.
+
+package tempfile
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	tt "github.com/apcera/util/testtool"
+)
+
+func TestTempFile(t *testing.T) {
+	r := strings.NewReader("blah")
+	f, err := New(r)
+	tt.TestExpectSuccess(t, err)
+
+	b, err := ioutil.ReadAll(f)
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, string(b), "blah")
+
+	tf := f.(*unlinkOnCloseFile)
+	st, err := os.Stat(tf.File.Name())
+	tt.TestExpectSuccess(t, err)
+	tt.TestNotEqual(t, st, nil)
+
+	tt.TestExpectSuccess(t, f.Close())
+
+	_, err = os.Stat(tf.File.Name())
+	tt.TestExpectError(t, err)
+	tt.TestEqual(t, os.IsNotExist(err), true)
+}


### PR DESCRIPTION
Added the tempfile package, which can be used to take in a reader,
reads all of its content to a local temporary file, and handles removing
the temp file automatically on deletion.

The interface it has allows reading, seeking, and closing.

This allows the logic to handle opening a file, whether local or remote,
in one place of code, and the logic for using that data in another
place. This allows the opening logic to not need to clean it up, it will
self-cleanup.

FYI PR, had this code in kurma and in the verse repo, figured best to just move it to util rather than duplicate.