### PR TITLE
Added flag to allow user to exclude ./ so untarring doesn't modify the parent directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: go
 go:
-  - 1.3
+  - 1.5
   - 1.4
+  - 1.3
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq liblzma-dev
 
 install:
-  - go get golang.org/x/tools/cmd/vet
+  - go get -u golang.org/x/tools/cmd/vet
   - go get github.com/appc/spec/discovery
   - go get github.com/apcera/logray
 

--- a/tarhelper/tar_test.go
+++ b/tarhelper/tar_test.go
@@ -62,6 +62,56 @@ func TestTarVirtualPath(t *testing.T) {
 	TestExpectSuccess(t, tw.Archive())
 }
 
+func TestExcludeRootPath(t *testing.T) {
+	StartTest(t)
+	defer FinishTest(t)
+
+	w := bytes.NewBufferString("")
+	tw := NewTar(w, makeTestDir(t))
+	tw.ExcludeRootPath = true
+	TestEqual(t, tw.excludeRootPath("./"), true)
+	TestExpectSuccess(t, tw.Archive())
+
+	archive := tar.NewReader(w)
+	rootHeader := ""
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if header.Name == "./" {
+			rootHeader = header.Name
+		}
+	}
+
+	TestNotEqual(t, rootHeader, "./")
+}
+
+func TestIncludeRootPath(t *testing.T) {
+	StartTest(t)
+	defer FinishTest(t)
+
+	w := bytes.NewBufferString("")
+	tw := NewTar(w, makeTestDir(t))
+	tw.ExcludeRootPath = false
+	TestEqual(t, tw.excludeRootPath("./"), false)
+	TestExpectSuccess(t, tw.Archive())
+
+	archive := tar.NewReader(w)
+	rootHeader := ""
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if header.Name == "./" {
+			rootHeader = header.Name
+		}
+	}
+
+	TestEqual(t, rootHeader, "./")
+}
+
 func TestPathExclusion(t *testing.T) {
 	StartTest(t)
 	defer FinishTest(t)


### PR DESCRIPTION
Added option to ignore ./ in the tar header. This fixes a bug reported to Derek when expanding the gnatsd release file. 

@krobertson @wallyqs @derekcollison 