### PR TITLE
docker: handle scheme-ish image names

### DIFF
--- a/docker/registry_url.go
+++ b/docker/registry_url.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
 
 package docker
 
@@ -53,7 +53,7 @@ func ParseDockerRegistryURL(s string) (*DockerRegistryURL, error) {
 		return registryURL, nil
 	}
 	// String didn't parse but was supposed to be a full registry URL.
-	if strings.HasPrefix(s, "http") || strings.HasPrefix(s, "https") {
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
 		return nil, fmt.Errorf("Invalid full Docker registry URL: %s", err)
 	}
 

--- a/docker/registry_url_test.go
+++ b/docker/registry_url_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Apcera Inc. All rights reserved.
+// Copyright 2015-2016 Apcera Inc. All rights reserved.
 
 package docker
 
@@ -46,6 +46,13 @@ func TestParseDockerRegistryURL(t *testing.T) {
 			&DockerRegistryURL{
 				ImageName: "repo",
 				Tag:       "tag",
+			},
+		},
+		{
+			"httpd",
+			nil,
+			&DockerRegistryURL{
+				ImageName: "httpd",
 			},
 		},
 		{


### PR DESCRIPTION
Passing in an image name of `httpd` would cause the parsing function to treat
the input as a partial image name, rather than a URL.

@wallyqs @jpoler 