### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.6
-  - 1.5
-  - 1.4
+  - 1.5.4
+  - 1.6.2
+  - tip
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - sudo apt-get install -qq liblzma-dev
 
 install:
-  - go get -u golang.org/x/tools/cmd/vet
   - go get github.com/appc/spec/discovery
   - go get github.com/apcera/logray
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
+  - 1.6
   - 1.5
   - 1.4
-  - 1.3
 
 before_install:
   - sudo apt-get update -qq

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -115,7 +115,7 @@ func TestInterfaceStats(t *testing.T) {
 
 	expect := func(expected InterfaceStat, returned InterfaceStat) {
 		if expected.Device != returned.Device {
-			Fatalf(t, "Expected Device=%d, got %d",
+			Fatalf(t, "Expected Device=%s, got %s",
 				expected.Device, returned.Device)
 		} else if expected.RxBytes != returned.RxBytes {
 			Fatalf(t, "Expected RxBytes=%d, got %d",


### PR DESCRIPTION
Was getting an error when attempting to retrieve go vet. I don't know why we were doing this, since it appears to already be present. Other repos weren't retrieving it anymore.

Upstream libraries from AppC discovery and some of its dependencies were no longer Go 1.3 compatible. We don't use 1.3 either. So removed testing on 1.3 and added in testing on 1.6.