### PR TITLE
Fix bug with Windows absolute paths

### DIFF
--- a/tarhelper/untar.go
+++ b/tarhelper/untar.go
@@ -441,6 +441,13 @@ func (u *Untar) processEntry(header *tar.Header) error {
 func (u *Untar) resolveDestination(name string) (string, error) {
 	pathParts := strings.Split(name, string(os.PathSeparator))
 
+	// On Windows, Split will remove the '\' from "C:\". This would cause
+	// Extract to extract to the wrong directory. Here we detect this issue and
+	// insert the missing trailing '\' when necessary.
+	if runtime.GOOS == "windows" && filepath.IsAbs(name) {
+		pathParts[0] += string(os.PathSeparator)
+	}
+
 	// walk the path parts to find at what point the resolvedLinks deviates
 	i := 0
 	for i, _ = range pathParts {


### PR DESCRIPTION
We encountered a problem in `apcera-setup` on Windows where the `orchestrator` and `deploy` .ova images did not extract to the correct directory.
```
# expected
C:\Users\foo\apcera-setup\
    images\
        trusty-deploy-virtualbox.tar.gz
        trusty-deploy-virtualbox-latest.ova

# got
C:\Users\foo\apcera-setup\
    images\trusty-deploy-virtualbox.tar.gz
    Users\
        foo\
            apcera-setup\
                images\
                    trusty-deploy-virtualbox-latest.ova
```
`tarhelper` was being given an _absolute_ destination path like `C:\Users\foo\apcera-setup\images\foo.ova` and was treating it like a _relative_ path. This happened because the `\` was being stripped from `C:\` in `resolveDestination`. This patch reinserts the slash after it has been stripped.

Props to @mbhinder for the fix.

Fixes ENGT-7846

@mbhinder @krobertson @alextoombs 