### PR TITLE
dockertest/v2: return expected registry header

### DIFF
--- a/dockertest/v2/mock_v2_registry.go
+++ b/dockertest/v2/mock_v2_registry.go
@@ -78,6 +78,9 @@ func writeResponse(w http.ResponseWriter, httpStatus int, payload interface{}) {
 }
 
 func checkAuth(w http.ResponseWriter, r *http.Request) bool {
+	header := w.Header()
+	header.Add("Docker-Distribution-API-Version", "registry/2.0")
+
 	if skipAuth {
 		return true
 	}


### PR DESCRIPTION
The `docker2aci` client expected this value, but our mock registry was
not returning the header properly. This brings the mock registry closer
in-line with the v2 registry API spec.

@wallyqs @krobertson @mbhinder 