### PR TITLE
Make sure to close all restclient connections for reliablity

### DIFF
--- a/restclient/restclient.go
+++ b/restclient/restclient.go
@@ -258,6 +258,7 @@ func (r *Request) HTTPRequest() (*http.Request, error) {
 
 	// merge headers
 	req.Header = r.Headers
+	req.Close = true
 
 	// generate the body
 	if r.prepare != nil {


### PR DESCRIPTION
This just makes sure requests coming from restclient close the connection when completed. It fixes the issues described here:

https://github.com/golang/go/commit/5dd372bd1e70949a432d9b7b8b021d13abf584d1

Unfortunately this only fixes idempotent requests (GETs), not POST/PUT which we use for the SG's. We are seeing EOF errors on those requests as well, so testing this to see if it resolves the issue.

We also allow customers to write SG's and they may not handle persistent connections correctly either, so this is a safer implementation.

@krobertson @shobhit85 @mbhinder 