### PR TITLE
Don't set ResponseHeaderTimeout for restclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.5.4
   - 1.6.2
   - tip
 

--- a/restclient/restclient.go
+++ b/restclient/restclient.go
@@ -61,6 +61,7 @@ func New(baseurl string) (*Client, error) {
 
 	transport := http.DefaultTransport.(*http.Transport)
 	transport.ResponseHeaderTimeout = 0 * time.Second
+	transport.ExpectContinueTimeout = 5 * time.Second
 
 	// create the client
 	client := &Client{

--- a/restclient/restclient.go
+++ b/restclient/restclient.go
@@ -59,9 +59,14 @@ func New(baseurl string) (*Client, error) {
 		return nil, fmt.Errorf("URL is not absolute: %s", baseurl)
 	}
 
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.ResponseHeaderTimeout = 0 * time.Second
+
 	// create the client
 	client := &Client{
-		Driver:  &http.Client{}, // Don't use default client; shares by reference
+		Driver: &http.Client{
+			Transport: transport,
+		}, // Don't use default client; shares by reference
 		base:    base,
 		Headers: http.Header(make(map[string][]string)),
 	}


### PR DESCRIPTION
Just removes the ResponseHeaderTimeout to avoid errors like:

http://tc.apcera.net/viewLog.html?buildId=251619&buildTypeId=SystemTests_MasterTesting_DeployTestMasterAwsMultiCentral&tab=buildLog#_focus=907

@krobertson @tw4dl @variadico @mbhinder @shobhit85 @kelingel 