### PR TITLE
Revert "Don't set ResponseHeaderTimeout for restclient"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.5.4
   - 1.6.2
   - tip
 

--- a/restclient/restclient.go
+++ b/restclient/restclient.go
@@ -59,15 +59,9 @@ func New(baseurl string) (*Client, error) {
 		return nil, fmt.Errorf("URL is not absolute: %s", baseurl)
 	}
 
-	transport := http.DefaultTransport.(*http.Transport)
-	transport.ResponseHeaderTimeout = 0 * time.Second
-	transport.ExpectContinueTimeout = 5 * time.Second
-
 	// create the client
 	client := &Client{
-		Driver: &http.Client{
-			Transport: transport,
-		}, // Don't use default client; shares by reference
+		Driver:  &http.Client{}, // Don't use default client; shares by reference
 		base:    base,
 		Headers: http.Header(make(map[string][]string)),
 	}


### PR DESCRIPTION
Reverts apcera/util#48 for now to reduce our suspicious numbers, at least it didn't fix the problem, we can reopen it later if we find out the root cause.

@krobertson @zquestz @wallyqs @shobhit85  