### PR TITLE
testtool: Use DeepEqual

### DIFF
--- a/docker/v1/registry_test.go
+++ b/docker/v1/registry_test.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 func TestGetImage(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("", "")
 	tt.TestExpectError(t, err)
@@ -39,8 +39,8 @@ func TestGetImage(t *testing.T) {
 }
 
 func TestGetImageHistory(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("foo/bar", "")
 	tt.TestExpectSuccess(t, err)
@@ -58,8 +58,8 @@ func TestGetImageHistory(t *testing.T) {
 }
 
 func TestGetImageTags(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("foo/bar", "")
 	tt.TestExpectSuccess(t, err)
@@ -71,8 +71,8 @@ func TestGetImageTags(t *testing.T) {
 }
 
 func TestGetImageTagLayerID(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("foo/bar", "")
 	tt.TestExpectSuccess(t, err)
@@ -92,8 +92,8 @@ func TestGetImageTagLayerID(t *testing.T) {
 }
 
 func TestGetImageMetadata(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("foo/bar", "")
 	tt.TestExpectSuccess(t, err)
@@ -120,8 +120,8 @@ func TestGetImageMetadata(t *testing.T) {
 }
 
 func TestReadLayer(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	img, statusCode, err := GetImage("foo/bar", "")
 	tt.TestExpectSuccess(t, err)

--- a/envmap/envmap_test.go
+++ b/envmap/envmap_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestEnvMapSimple(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Simple case.
 	e := NewEnvMap()
@@ -30,8 +30,8 @@ func TestEnvMapSimple(t *testing.T) {
 }
 
 func TestEnvMapRecursive(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Simple case.
 	e := NewEnvMap()
@@ -52,8 +52,8 @@ func TestEnvMapRecursive(t *testing.T) {
 }
 
 func TestEnvMapDoubleAdd(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Simple case.
 	e := NewEnvMap()
@@ -70,8 +70,8 @@ func TestEnvMapDoubleAdd(t *testing.T) {
 }
 
 func TestEnvMap(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	expected := []string{
 		"START_COMMAND=XYZ",
@@ -131,8 +131,8 @@ func TestEnvMap(t *testing.T) {
 }
 
 func TestEnvMapGetRaw(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	root := NewEnvMap()
 	root.Set("VARIABLE", "foo bar $STR")
@@ -155,8 +155,8 @@ func TestEnvMapGetRaw(t *testing.T) {
 }
 
 func TestEnvMapGetUnflattened(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	root := NewEnvMap()
 	root.Set("VARIABLE", "foo bar $STR")
@@ -172,8 +172,8 @@ func TestEnvMapGetUnflattened(t *testing.T) {
 }
 
 func TestJsonMarshalUnmarshal(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	e := NewEnvMap()
 	e.Set("A", "1")

--- a/hmac/hmac_test.go
+++ b/hmac/hmac_test.go
@@ -10,8 +10,8 @@ import (
 
 // Make sure that HMAC Sha1 is calculated correctly
 func TestComputeHmacSha1(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	hmacSha1 := ComputeHmacSha1("message", "secret")
 	tt.TestEqual(t, hmacSha1, "DK9kn+7klT2Hv5A6wRdsReAo3xY=")

--- a/proc/parser_test.go
+++ b/proc/parser_test.go
@@ -11,34 +11,34 @@ import (
 )
 
 func TestReadInt64(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
-	f := tt.WriteTempFile(t, "foo\nbar")
+	f := testHelper.WriteTempFile("foo\nbar")
 
 	_, err := ReadInt64(f)
 	tt.TestExpectError(t, err)
 
-	f = tt.WriteTempFile(t, "123\n456")
+	f = testHelper.WriteTempFile("123\n456")
 
 	v, err := ReadInt64(f)
 	tt.TestExpectSuccess(t, err)
 	tt.TestEqual(t, v, int64(123))
 
-	f = tt.WriteTempFile(t, "123456789")
+	f = testHelper.WriteTempFile("123456789")
 	v, err = ReadInt64(f)
 	tt.TestExpectSuccess(t, err)
 	tt.TestEqual(t, v, int64(123456789))
 
 	maxInt64 := fmt.Sprintf("%d", int64(1<<63-1))
-	f = tt.WriteTempFile(t, maxInt64)
+	f = testHelper.WriteTempFile(maxInt64)
 
 	v, err = ReadInt64(f)
 	tt.TestExpectSuccess(t, err)
 	tt.TestEqual(t, v, int64(1<<63-1))
 
 	maxInt64WithExtra := fmt.Sprintf("%d666", int64(1<<63-1))
-	f = tt.WriteTempFile(t, maxInt64WithExtra)
+	f = testHelper.WriteTempFile(maxInt64WithExtra)
 
 	v, err = ReadInt64(f)
 	tt.TestExpectSuccess(t, err)
@@ -46,8 +46,8 @@ func TestReadInt64(t *testing.T) {
 }
 
 func TestParseSimpleProcFile(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Test 1: Success.
 	lines := []string{
@@ -55,7 +55,7 @@ func TestParseSimpleProcFile(t *testing.T) {
 		" belm0  belm1\t belm2\t\t\t",
 		"",
 		"delm0"}
-	f := tt.WriteTempFile(t, strings.Join(lines, "\n"))
+	f := testHelper.WriteTempFile(strings.Join(lines, "\n"))
 	err := ParseSimpleProcFile(
 		f,
 		func(index int, line string) error {

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -6,164 +6,164 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/apcera/util/testtool"
+	tt "github.com/apcera/util/testtool"
 )
 
 func TestMountPoints(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Test 1: Very basic /proc/mounts file. Ensure that each
 	//         field is properly parsed, the order is correct, etc.
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"rootfs1 / rootfs2 rw 0 0",
 	}, "\n"))
 	if mp, err := MountPoints(); err != nil {
-		Fatalf(t, "Error from MountPoints: %s", err)
+		tt.Fatalf(t, "Error from MountPoints: %s", err)
 	} else if len(mp) != 1 {
-		Fatalf(t, "Bad return value: %#v", mp)
+		tt.Fatalf(t, "Bad return value: %#v", mp)
 	} else if mp["/"].Dev != "rootfs1" {
-		Fatalf(t, "invalid device: %s", mp["/"].Dev)
+		tt.Fatalf(t, "invalid device: %s", mp["/"].Dev)
 	} else if mp["/"].Path != "/" {
-		Fatalf(t, "invalid path: %s", mp["/"].Path)
+		tt.Fatalf(t, "invalid path: %s", mp["/"].Path)
 	} else if mp["/"].Fstype != "rootfs2" {
-		Fatalf(t, "invalid file system type: %s", mp["/"].Fstype)
+		tt.Fatalf(t, "invalid file system type: %s", mp["/"].Fstype)
 	} else if mp["/"].Options != "rw" {
-		Fatalf(t, "invalid options: %s", mp["/"].Options)
+		tt.Fatalf(t, "invalid options: %s", mp["/"].Options)
 	} else if mp["/"].Dump != 0 {
-		Fatalf(t, "invalid dump value: %d", mp["/"].Dump)
+		tt.Fatalf(t, "invalid dump value: %d", mp["/"].Dump)
 	} else if mp["/"].Fsck != 0 {
-		Fatalf(t, "invalid fsck value: %d", mp["/"].Fsck)
+		tt.Fatalf(t, "invalid fsck value: %d", mp["/"].Fsck)
 	}
 
 	// Test 2: Priority, two mounts in the same path. Ensure that
 	//         the last listed always wins.
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"bad / bad bad 1 1",
 		"rootfs1 / rootfs2 rw 0 0",
 	}, "\n"))
 	if mp, err := MountPoints(); err != nil {
-		Fatalf(t, "Error from MountPoints: %s", err)
+		tt.Fatalf(t, "Error from MountPoints: %s", err)
 	} else if len(mp) != 1 {
-		Fatalf(t, "Bad return value: %#v", mp)
+		tt.Fatalf(t, "Bad return value: %#v", mp)
 	} else if mp["/"].Dev != "rootfs1" {
-		Fatalf(t, "invalid device: %s", mp["/"].Dev)
+		tt.Fatalf(t, "invalid device: %s", mp["/"].Dev)
 	} else if mp["/"].Path != "/" {
-		Fatalf(t, "invalid path: %s", mp["/"].Path)
+		tt.Fatalf(t, "invalid path: %s", mp["/"].Path)
 	} else if mp["/"].Fstype != "rootfs2" {
-		Fatalf(t, "invalid file system type: %s", mp["/"].Fstype)
+		tt.Fatalf(t, "invalid file system type: %s", mp["/"].Fstype)
 	} else if mp["/"].Options != "rw" {
-		Fatalf(t, "invalid options: %s", mp["/"].Options)
+		tt.Fatalf(t, "invalid options: %s", mp["/"].Options)
 	} else if mp["/"].Dump != 0 {
-		Fatalf(t, "invalid dump value: %d", mp["/"].Dump)
+		tt.Fatalf(t, "invalid dump value: %d", mp["/"].Dump)
 	} else if mp["/"].Fsck != 0 {
-		Fatalf(t, "invalid fsck value: %d", mp["/"].Fsck)
+		tt.Fatalf(t, "invalid fsck value: %d", mp["/"].Fsck)
 	}
 
 	// Test 3: Bad path value (relative or otherwise invalid.)
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev badpath fstype options 0 0",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 
 	// Test 4: Bad dump value (not an int)
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev / fstype options bad 0",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 
 	// Test 5: Bad dump value (negative)
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev / fstype options -1 0",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 
 	// Test 6: Bad dump value (not an int)
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev / fstype options 0 bad",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 
 	// Test 7: Bad dump value (negative)
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev / fstype options 0 -1",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 
 	// Test 8: Too many columns.
-	MountProcFile = WriteTempFile(t, strings.Join([]string{
+	MountProcFile = testHelper.WriteTempFile(strings.Join([]string{
 		"dev / fstype options 0 0 extra",
 	}, "\n"))
 	if _, err := MountPoints(); err == nil {
-		Fatalf(t, "Expected an error from MountPoints()")
+		tt.Fatalf(t, "Expected an error from MountPoints()")
 	}
 }
 
 func TestInterfaceStats(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	expect := func(expected InterfaceStat, returned InterfaceStat) {
 		if expected.Device != returned.Device {
-			Fatalf(t, "Expected Device=%s, got %s",
+			tt.Fatalf(t, "Expected Device=%s, got %s",
 				expected.Device, returned.Device)
 		} else if expected.RxBytes != returned.RxBytes {
-			Fatalf(t, "Expected RxBytes=%d, got %d",
+			tt.Fatalf(t, "Expected RxBytes=%d, got %d",
 				expected.RxBytes, returned.RxBytes)
 		} else if expected.RxPackets != returned.RxPackets {
-			Fatalf(t, "Expected RxPackets=%d, got %d",
+			tt.Fatalf(t, "Expected RxPackets=%d, got %d",
 				expected.RxPackets, returned.RxPackets)
 		} else if expected.RxErrors != returned.RxErrors {
-			Fatalf(t, "Expected RxErrors=%d, got %d",
+			tt.Fatalf(t, "Expected RxErrors=%d, got %d",
 				expected.RxErrors, returned.RxErrors)
 		} else if expected.RxDrop != returned.RxDrop {
-			Fatalf(t, "Expected RxDrop=%d, got %d",
+			tt.Fatalf(t, "Expected RxDrop=%d, got %d",
 				expected.RxDrop, returned.RxDrop)
 		} else if expected.RxFifo != returned.RxFifo {
-			Fatalf(t, "Expected RxFifo=%d, got %d",
+			tt.Fatalf(t, "Expected RxFifo=%d, got %d",
 				expected.RxFifo, returned.RxFifo)
 		} else if expected.RxFrame != returned.RxFrame {
-			Fatalf(t, "Expected RxFrame=%d, got %d",
+			tt.Fatalf(t, "Expected RxFrame=%d, got %d",
 				expected.RxFrame, returned.RxFrame)
 		} else if expected.RxCompressed != returned.RxCompressed {
-			Fatalf(t, "Expected RxCompressed=%d, got %d",
+			tt.Fatalf(t, "Expected RxCompressed=%d, got %d",
 				expected.RxCompressed, returned.RxCompressed)
 		} else if expected.RxMulticast != returned.RxMulticast {
-			Fatalf(t, "Expected RxMulticast=%d, got %d",
+			tt.Fatalf(t, "Expected RxMulticast=%d, got %d",
 				expected.RxMulticast, returned.RxMulticast)
 		} else if expected.TxBytes != returned.TxBytes {
-			Fatalf(t, "Expected TxBytes=%d, got %d",
+			tt.Fatalf(t, "Expected TxBytes=%d, got %d",
 				expected.TxBytes, returned.TxBytes)
 		} else if expected.TxPackets != returned.TxPackets {
-			Fatalf(t, "Expected TxPackets=%d, got %d",
+			tt.Fatalf(t, "Expected TxPackets=%d, got %d",
 				expected.TxPackets, returned.TxPackets)
 		} else if expected.TxErrors != returned.TxErrors {
-			Fatalf(t, "Expected TxErrors=%d, got %d",
+			tt.Fatalf(t, "Expected TxErrors=%d, got %d",
 				expected.TxErrors, returned.TxErrors)
 		} else if expected.TxDrop != returned.TxDrop {
-			Fatalf(t, "Expected TxDrop=%d, got %d",
+			tt.Fatalf(t, "Expected TxDrop=%d, got %d",
 				expected.TxDrop, returned.TxDrop)
 		} else if expected.TxFifo != returned.TxFifo {
-			Fatalf(t, "Expected TxFifo=%d, got %d",
+			tt.Fatalf(t, "Expected TxFifo=%d, got %d",
 				expected.TxFifo, returned.TxFifo)
 		} else if expected.TxFrame != returned.TxFrame {
-			Fatalf(t, "Expected TxFrame=%d, got %d",
+			tt.Fatalf(t, "Expected TxFrame=%d, got %d",
 				expected.TxFrame, returned.TxFrame)
 		} else if expected.TxCompressed != returned.TxCompressed {
-			Fatalf(t, "Expected TxCompressed=%d, got %d",
+			tt.Fatalf(t, "Expected TxCompressed=%d, got %d",
 				expected.TxCompressed, returned.TxCompressed)
 		} else if expected.TxMulticast != returned.TxMulticast {
-			Fatalf(t, "Expected TxMulticast=%d, got %d",
+			tt.Fatalf(t, "Expected TxMulticast=%d, got %d",
 				expected.TxMulticast, returned.TxMulticast)
 		}
 	}
@@ -172,7 +172,7 @@ func TestInterfaceStats(t *testing.T) {
 	// Test 1: Real simple use case.
 	// -----------------------------
 
-	DeviceStatsFile = WriteTempFile(t, strings.Join([]string{
+	DeviceStatsFile = testHelper.WriteTempFile(strings.Join([]string{
 		"header 1",
 		"header 2",
 		"dev0: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16",
@@ -197,9 +197,9 @@ func TestInterfaceStats(t *testing.T) {
 		TxMulticast:  16,
 	}
 	if stats, err := InterfaceStats(); err != nil {
-		Fatalf(t, "Error from TestInterfaceStats: %s", err)
+		tt.Fatalf(t, "Error from TestInterfaceStats: %s", err)
 	} else if len(stats) != 1 {
-		Fatalf(t, "Bad return value: %#v", stats)
+		tt.Fatalf(t, "Bad return value: %#v", stats)
 	} else {
 		expect(expected, stats["dev0"])
 	}
@@ -208,12 +208,12 @@ func TestInterfaceStats(t *testing.T) {
 	// Test 2: Invalid format
 	// -----------------------------
 
-	DeviceStatsFile = WriteTempFile(t, strings.Join([]string{
+	DeviceStatsFile = testHelper.WriteTempFile(strings.Join([]string{
 		"header 1",
 		"header 2",
 		"dev0: NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN",
 	}, "\n"))
 	if _, err := InterfaceStats(); err == nil {
-		Fatalf(t, "Expected error not returned.")
+		tt.Fatalf(t, "Expected error not returned.")
 	}
 }

--- a/restclient/restclient_test.go
+++ b/restclient/restclient_test.go
@@ -22,8 +22,8 @@ type person struct {
 }
 
 func TestResourceURL(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	base := "http://example.com:8080/v1/resources"
 	baseURL, err := url.Parse(base)
@@ -47,8 +47,8 @@ func TestResourceURL(t *testing.T) {
 }
 
 func TestHelper_newRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	client, err := New("http://example.com/resources")
 	tt.TestExpectSuccess(t, err)
@@ -60,8 +60,8 @@ func TestHelper_newRequest(t *testing.T) {
 }
 
 func TestHelper_newRequestWithParams(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	client, err := New("http://example.com/resources")
 	tt.TestExpectSuccess(t, err)
@@ -73,8 +73,8 @@ func TestHelper_newRequestWithParams(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	method, path, body := "", "", ""
@@ -107,8 +107,8 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestNewRequestHeaders(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	headerValue := ""
@@ -131,8 +131,8 @@ func TestNewRequestHeaders(t *testing.T) {
 }
 
 func TestBasicJsonRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	method, path, body := "", "", ""
@@ -173,8 +173,8 @@ func TestBasicJsonRequest(t *testing.T) {
 }
 
 func TestJsonStructRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	var receivedPerson *person
 
@@ -210,8 +210,8 @@ func TestJsonStructRequest(t *testing.T) {
 }
 
 func TestFormRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	var form url.Values
@@ -239,8 +239,8 @@ func TestFormRequest(t *testing.T) {
 }
 
 func TestErrorResult(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -274,8 +274,8 @@ func TestErrorResult(t *testing.T) {
 }
 
 func TestErrorResponse(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -303,8 +303,8 @@ func TestErrorResponse(t *testing.T) {
 }
 
 func TestErrorResponseWithJson(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -332,8 +332,8 @@ func TestErrorResponseWithJson(t *testing.T) {
 }
 
 func TestErrorResponseNoBody(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -359,8 +359,8 @@ func TestErrorResponseNoBody(t *testing.T) {
 }
 
 func TestInvalidJsonResponse(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -381,8 +381,8 @@ func TestInvalidJsonResponse(t *testing.T) {
 }
 
 func TestParseMimetype(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -404,8 +404,8 @@ func TestParseMimetype(t *testing.T) {
 }
 
 func TestEmptyPostRequest(t *testing.T) {
-	tt.StartTest(t)
-	defer tt.FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a test server
 	body := ""

--- a/tarhelper/tar_test.go
+++ b/tarhelper/tar_test.go
@@ -13,65 +13,68 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/apcera/util/testtool"
+	tt "github.com/apcera/util/testtool"
 )
 
 func makeTestDir(t *testing.T) string {
+	testHelper := tt.StartTest(t)
+	//defer testHelper.FinishTest()
+
 	cwd, err := os.Getwd()
-	TestExpectSuccess(t, err)
-	AddTestFinalizer(func() {
-		TestExpectSuccess(t, os.Chdir(cwd))
+	tt.TestExpectSuccess(t, err)
+	testHelper.AddTestFinalizer(func() {
+		tt.TestExpectSuccess(t, os.Chdir(cwd))
 	})
-	dir := TempDir(t)
-	TestExpectSuccess(t, os.Chdir(dir))
+	dir := testHelper.TempDir()
+	tt.TestExpectSuccess(t, os.Chdir(dir))
 	mode := os.FileMode(0755)
 	os.Mkdir(cwd, mode) //Don't care about return value.  For some reason CWD is not created by go test on all systems.
-	TestExpectSuccess(t, os.Mkdir("a", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i/j", mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/c/d/e", []byte{}, mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/c/f", []byte{}, mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/g", []byte{}, mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j/k", []byte{}, mode))
-	TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
-	TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
-	TestExpectSuccess(t, os.Symlink("g", "a/b/h"))
-	TestExpectSuccess(t, os.Symlink("k", "a/b/i/j/l"))
-	TestExpectSuccess(t, os.Symlink("../../g", "a/b/i/j/m"))
+	tt.TestExpectSuccess(t, os.Mkdir("a", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i/j", mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/c/d/e", []byte{}, mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/c/f", []byte{}, mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/g", []byte{}, mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j/k", []byte{}, mode))
+	tt.TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
+	tt.TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
+	tt.TestExpectSuccess(t, os.Symlink("g", "a/b/h"))
+	tt.TestExpectSuccess(t, os.Symlink("k", "a/b/i/j/l"))
+	tt.TestExpectSuccess(t, os.Symlink("../../g", "a/b/i/j/m"))
 	return dir
 }
 
 func TestTarSimple(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 }
 
 func TestTarVirtualPath(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
 	tw.VirtualPath = "foo"
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 }
 
 func TestExcludeRootPath(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
 	tw.ExcludeRootPath = true
-	TestEqual(t, tw.excludeRootPath("./"), true)
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestEqual(t, tw.excludeRootPath("./"), true)
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	archive := tar.NewReader(w)
 	rootHeader := ""
@@ -85,18 +88,18 @@ func TestExcludeRootPath(t *testing.T) {
 		}
 	}
 
-	TestNotEqual(t, rootHeader, "./")
+	tt.TestNotEqual(t, rootHeader, "./")
 }
 
 func TestIncludeRootPath(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
 	tw.ExcludeRootPath = false
-	TestEqual(t, tw.excludeRootPath("./"), false)
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestEqual(t, tw.excludeRootPath("./"), false)
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	archive := tar.NewReader(w)
 	rootHeader := ""
@@ -110,12 +113,12 @@ func TestIncludeRootPath(t *testing.T) {
 		}
 	}
 
-	TestEqual(t, rootHeader, "./")
+	tt.TestEqual(t, rootHeader, "./")
 }
 
 func TestPathExclusion(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	type testcase struct {
 		RE       string // e.g. "p.*h"
@@ -186,9 +189,9 @@ func TestPathExclusion(t *testing.T) {
 	// test the "empty exclusion list" cases
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
-	TestEqual(t, tw.shouldBeExcluded("/any/thing", false), false)
+	tt.TestEqual(t, tw.shouldBeExcluded("/any/thing", false), false)
 	tw.ExcludePath("")
-	TestEqual(t, tw.shouldBeExcluded("/any/thing", false), false)
+	tt.TestEqual(t, tw.shouldBeExcluded("/any/thing", false), false)
 
 	// test these cases on new instances of Tar object to avoid any
 	// possible side effects/conflicts
@@ -215,13 +218,13 @@ func TestPathExclusion(t *testing.T) {
 		}
 
 		for _, path := range stdPaths {
-			TestEqual(t, tw.shouldBeExcluded(path, false), tc.Expected[path],
+			tt.TestEqual(t, tw.shouldBeExcluded(path, false), tc.Expected[path],
 				fmt.Sprintf("Path:%q, tc:%v", path, tc))
 			delete(tc.Expected, path)
 		}
 
 		for path, exp := range tc.Expected {
-			TestEqual(t, tw.shouldBeExcluded(path, false), exp)
+			tt.TestEqual(t, tw.shouldBeExcluded(path, false), exp)
 		}
 	}
 
@@ -233,14 +236,14 @@ func TestPathExclusion(t *testing.T) {
 	tw.ExcludePath("/two/two/.*")
 	tw.ExcludePath("/three/three/three.*")
 	var fi staticFileInfo
-	TestExpectSuccess(t, tw.processEntry("/one/something", fi, []string{}))
-	TestExpectSuccess(t, tw.processEntry("/two/two/something", fi, []string{}))
-	TestExpectSuccess(t, tw.processEntry("/three/three/three-something", fi, []string{}))
+	tt.TestExpectSuccess(t, tw.processEntry("/one/something", fi, []string{}))
+	tt.TestExpectSuccess(t, tw.processEntry("/two/two/something", fi, []string{}))
+	tt.TestExpectSuccess(t, tw.processEntry("/three/three/three-something", fi, []string{}))
 }
 
 func TestTarIDMapping(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// set up our mapping funcs
 	uidFuncCalled := false
@@ -260,7 +263,7 @@ func TestTarIDMapping(t *testing.T) {
 	tw.IncludeOwners = true
 	tw.OwnerMappingFunc = uidMappingFunc
 	tw.GroupMappingFunc = gidMappingFunc
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	// untar it and verify all of the uid/gids are 0
 	archive := tar.NewReader(w)
@@ -269,61 +272,61 @@ func TestTarIDMapping(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		TestExpectSuccess(t, err)
-		TestEqual(t, header.Uid, 0)
-		TestEqual(t, header.Gid, 0)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, header.Uid, 0)
+		tt.TestEqual(t, header.Gid, 0)
 	}
 }
 
 func TestSymlinkOptDereferenceLinkToFile(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
 	cwd, err := os.Getwd()
-	TestExpectSuccess(t, err)
-	AddTestFinalizer(func() {
-		TestExpectSuccess(t, os.Chdir(cwd))
+	tt.TestExpectSuccess(t, err)
+	testHelper.AddTestFinalizer(func() {
+		tt.TestExpectSuccess(t, os.Chdir(cwd))
 	})
 
-	StartTest(t)
-	defer FinishTest(t)
-
-	dir := TempDir(t)
-	TestExpectSuccess(t, os.Chdir(dir))
+	dir := testHelper.TempDir()
+	tt.TestExpectSuccess(t, os.Chdir(dir))
 	mode := os.FileMode(0755)
-	TestExpectSuccess(t, os.Mkdir("a", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
-	TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
-	TestExpectSuccess(t, os.Symlink("../i/j", "a/b/c/lj"))
+	tt.TestExpectSuccess(t, os.Mkdir("a", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
+	tt.TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
+	tt.TestExpectSuccess(t, os.Symlink("../i/j", "a/b/c/lj"))
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, dir)
 	tw.UserOptions |= c_DEREF
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	extractionPath := path.Join(dir, "pkg")
 	err = os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(w.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = dir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	dirExists := func(name string) {
 		f, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, true, f.IsDir())
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, true, f.IsDir())
 	}
 
 	sameFileContents := func(f1 string, f2 string) {
 		b1, err := ioutil.ReadFile(f1)
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 
 		b2, err := ioutil.ReadFile(f2)
-		TestExpectSuccess(t, err)
-		TestEqual(t, b1, b2)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, b1, b2)
 	}
 
 	// Verify dirs a, a/b, a/b/c, a/b/c/d
@@ -341,54 +344,54 @@ func TestSymlinkOptDereferenceLinkToFile(t *testing.T) {
 }
 
 func TestSymlinkOptDereferenceLinkToDir(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
 	cwd, err := os.Getwd()
-	TestExpectSuccess(t, err)
-	AddTestFinalizer(func() {
-		TestExpectSuccess(t, os.Chdir(cwd))
+	tt.TestExpectSuccess(t, err)
+	testHelper.AddTestFinalizer(func() {
+		tt.TestExpectSuccess(t, os.Chdir(cwd))
 	})
 
-	StartTest(t)
-	defer FinishTest(t)
-
-	dir := TempDir(t)
-	TestExpectSuccess(t, os.Chdir(dir))
+	dir := testHelper.TempDir()
+	tt.TestExpectSuccess(t, os.Chdir(dir))
 	mode := os.FileMode(0755)
-	TestExpectSuccess(t, os.Mkdir("a", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
-	TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
-	TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
+	tt.TestExpectSuccess(t, os.Mkdir("a", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
+	tt.TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
+	tt.TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, dir)
 	tw.UserOptions |= c_DEREF
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	extractionPath := path.Join(dir, "pkg")
 	err = os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(w.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = dir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	dirExists := func(name string) {
 		f, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, true, f.IsDir())
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, true, f.IsDir())
 	}
 
 	sameFileContents := func(f1 string, f2 string) {
 		b1, err := ioutil.ReadFile(f1)
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 
 		b2, err := ioutil.ReadFile(f2)
-		TestExpectSuccess(t, err)
-		TestEqual(t, b1, b2)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, b1, b2)
 	}
 
 	// Verify dirs a, a/b, a/b/c, a/b/c/d
@@ -406,60 +409,60 @@ func TestSymlinkOptDereferenceLinkToDir(t *testing.T) {
 }
 
 func TestSymlinkOptDereferenceCircular(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
 	cwd, err := os.Getwd()
-	TestExpectSuccess(t, err)
-	AddTestFinalizer(func() {
-		TestExpectSuccess(t, os.Chdir(cwd))
+	tt.TestExpectSuccess(t, err)
+	testHelper.AddTestFinalizer(func() {
+		tt.TestExpectSuccess(t, os.Chdir(cwd))
 	})
 
-	StartTest(t)
-	defer FinishTest(t)
-
-	dir := TempDir(t)
-	TestExpectSuccess(t, os.Chdir(dir))
+	dir := testHelper.TempDir()
+	tt.TestExpectSuccess(t, os.Chdir(dir))
 	mode := os.FileMode(0755)
-	TestExpectSuccess(t, os.Mkdir("a", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
-	TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
-	TestExpectSuccess(t, os.Symlink(dir+"/a/b/c/l", "a/b/i/ll"))
-	TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
+	tt.TestExpectSuccess(t, os.Mkdir("a", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
+	tt.TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
+	tt.TestExpectSuccess(t, os.Symlink(dir+"/a/b/c/l", "a/b/i/ll"))
+	tt.TestExpectSuccess(t, os.Symlink("../i", "a/b/c/l"))
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, dir)
 	tw.UserOptions |= c_DEREF
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	extractionPath := path.Join(dir, "pkg")
 	err = os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(w.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = dir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	dirExists := func(name string) {
 		f, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, true, f.IsDir())
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, true, f.IsDir())
 	}
 
 	sameFileContents := func(f1 string, f2 string) {
 		b1, err := ioutil.ReadFile(f1)
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 
 		b2, err := ioutil.ReadFile(f2)
-		TestExpectSuccess(t, err)
-		TestEqual(t, b1, b2)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, b1, b2)
 	}
 
 	// Verify dirs a, a/b, a/b/c, a/b/c/d
@@ -481,63 +484,63 @@ func TestSymlinkOptDereferenceCircular(t *testing.T) {
 
 	// Verify that the circular symbolic link a/b/i/ll does not exis
 	_, err = os.Stat(path.Join(extractionPath, "./a/b/i/ll"))
-	TestEqual(t, true, os.IsNotExist(err))
+	tt.TestEqual(t, true, os.IsNotExist(err))
 }
 
 func TestSymlinkOptDereferenceCircularToRoot(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
 	cwd, err := os.Getwd()
-	TestExpectSuccess(t, err)
-	AddTestFinalizer(func() {
-		TestExpectSuccess(t, os.Chdir(cwd))
+	tt.TestExpectSuccess(t, err)
+	testHelper.AddTestFinalizer(func() {
+		tt.TestExpectSuccess(t, os.Chdir(cwd))
 	})
 
-	StartTest(t)
-	defer FinishTest(t)
-
-	dir := TempDir(t)
-	TestExpectSuccess(t, os.Chdir(dir))
+	dir := testHelper.TempDir()
+	tt.TestExpectSuccess(t, os.Chdir(dir))
 	mode := os.FileMode(0755)
-	TestExpectSuccess(t, os.Mkdir("a", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
-	TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
-	TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
-	TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
-	TestExpectSuccess(t, os.Symlink(dir+"/a", "a/b/i/ll"))
+	tt.TestExpectSuccess(t, os.Mkdir("a", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/c/d", mode))
+	tt.TestExpectSuccess(t, os.Mkdir("a/b/i", mode))
+	tt.TestExpectSuccess(t, ioutil.WriteFile("a/b/i/j", []byte{'t', 'e', 's', 't'}, mode))
+	tt.TestExpectSuccess(t, os.Symlink("/bin/bash", "a/b/bash"))
+	tt.TestExpectSuccess(t, os.Symlink(dir+"/a", "a/b/i/ll"))
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, dir)
 	tw.UserOptions |= c_DEREF
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	extractionPath := path.Join(dir, "pkg")
 	err = os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(w.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = dir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	dirExists := func(name string) {
 		f, err := os.Stat(path.Join(extractionPath, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, true, f.IsDir())
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, true, f.IsDir())
 	}
 
 	sameFileContents := func(f1 string, f2 string) {
 		b1, err := ioutil.ReadFile(f1)
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 
 		b2, err := ioutil.ReadFile(f2)
-		TestExpectSuccess(t, err)
-		TestEqual(t, b1, b2)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, b1, b2)
 	}
 
 	// Verify dirs a, a/b, a/b/c, a/b/c/d
@@ -555,76 +558,76 @@ func TestSymlinkOptDereferenceCircularToRoot(t *testing.T) {
 
 	// Verify that the circular symbolic link a/b/i/ll does not exist
 	_, err = os.Stat(path.Join(extractionPath, "./a/b/i/ll"))
-	TestEqual(t, true, os.IsNotExist(err))
+	tt.TestEqual(t, true, os.IsNotExist(err))
 }
 
 func TestTarPointedToFile(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
-	dir := TempDir(t)
+	dir := testHelper.TempDir()
 	apath := path.Join(dir, "a")
 
 	// write the file, then read it the same way that we'll validate it
-	TestExpectSuccess(t, ioutil.WriteFile(apath, []byte("hello world"), os.FileMode(0644)))
+	tt.TestExpectSuccess(t, ioutil.WriteFile(apath, []byte("hello world"), os.FileMode(0644)))
 	contents, err := ioutil.ReadFile(apath)
-	TestExpectSuccess(t, err)
-	TestEqual(t, string(contents), "hello world")
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, string(contents), "hello world")
 
 	// tar the file
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, apath)
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	// should then also be able to untar it
-	dir = TempDir(t)
+	dir = testHelper.TempDir()
 	u := NewUntar(w, dir)
 	u.AbsoluteRoot = dir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	// stat it, ensure it exists and is a file, not a directory
 	stat, err := os.Stat(path.Join(dir, "a"))
-	TestExpectSuccess(t, err)
-	TestEqual(t, stat.IsDir(), false, "should be a file, not a directory")
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, stat.IsDir(), false, "should be a file, not a directory")
 
 	// read the contents to verify
 	contents, err = ioutil.ReadFile(path.Join(dir, "a"))
-	TestExpectSuccess(t, err)
-	TestEqual(t, string(contents), "hello world")
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, string(contents), "hello world")
 }
 
 func TestTarPreserveSetuid(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
-	dir := TempDir(t)
+	dir := testHelper.TempDir()
 	apath := path.Join(dir, "a")
 
 	err := ioutil.WriteFile(apath, []byte("hello world"), os.FileMode(0644))
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	err = os.Chmod(apath, os.FileMode(0644)|os.ModeSetuid)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, apath)
 	err = tw.Archive()
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
-	dir = TempDir(t)
+	dir = testHelper.TempDir()
 	u := NewUntar(w, dir)
 	u.AbsoluteRoot = dir
 	err = u.Extract()
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	stat, err := os.Stat(path.Join(dir, "a"))
-	TestExpectSuccess(t, err)
-	TestEqual(t, stat.Mode()&os.ModeSetuid != 0, true, "must have setuid bit")
+	tt.TestExpectSuccess(t, err)
+	tt.TestEqual(t, stat.Mode()&os.ModeSetuid != 0, true, "must have setuid bit")
 }
 
 func TestTarCustomHandler(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	w := bytes.NewBufferString("")
 	tw := NewTar(w, makeTestDir(t))
@@ -638,7 +641,7 @@ func TestTarCustomHandler(t *testing.T) {
 			return false, nil
 		},
 	}
-	TestExpectSuccess(t, tw.Archive())
+	tt.TestExpectSuccess(t, tw.Archive())
 
 	archive := tar.NewReader(w)
 	hasRenamedFile := false
@@ -648,14 +651,14 @@ func TestTarCustomHandler(t *testing.T) {
 			break
 		}
 		if header.Name == "a/b/i/j/m" {
-			Fatalf(t, "The \"a/b/i/j/m\" file should have been omitted")
+			tt.Fatalf(t, "The \"a/b/i/j/m\" file should have been omitted")
 		}
 		if header.Name == "a/b/i/j/n" {
 			hasRenamedFile = true
 		}
 	}
 
-	TestEqual(t, hasRenamedFile, true, "The tar file did not include the renamed file")
+	tt.TestEqual(t, hasRenamedFile, true, "The tar file did not include the renamed file")
 }
 
 type staticFileInfo struct{}

--- a/tarhelper/untar_test.go
+++ b/tarhelper/untar_test.go
@@ -17,12 +17,12 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/apcera/util/testtool"
+	tt "github.com/apcera/util/testtool"
 )
 
 func TestUntarResolveDestinations(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	u := new(Untar)
 	u.resolvedLinks = make([]resolvedLink, 0)
@@ -31,8 +31,8 @@ func TestUntarResolveDestinations(t *testing.T) {
 
 	runTest := func(p, e string) {
 		dst, err := u.resolveDestination(p)
-		TestExpectSuccess(t, err)
-		TestEqual(t, dst, e)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, dst, e)
 	}
 
 	runTest("a", "a")
@@ -64,8 +64,8 @@ func TestUntarResolveDestinations(t *testing.T) {
 }
 
 func TestUntarExtractFollowingSymlinks(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -78,7 +78,7 @@ func TestUntarExtractFollowingSymlinks(t *testing.T) {
 		header.Mode = 0755
 		header.Mode |= c_ISDIR
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	writeFile := func(name, contents string) {
@@ -91,10 +91,10 @@ func TestUntarExtractFollowingSymlinks(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Size = int64(len(b))
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	writeSymlink := func(name, link string) {
@@ -105,7 +105,7 @@ func TestUntarExtractFollowingSymlinks(t *testing.T) {
 		header.Mode = 0644
 		header.Mode |= c_ISLNK
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	// generate the mock tar
@@ -122,34 +122,34 @@ func TestUntarExtractFollowingSymlinks(t *testing.T) {
 	archive.Close()
 
 	// create temp folder to extract to
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 	extractionPath := path.Join(tempDir, "pkg")
 	err := os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 	err = os.MkdirAll(path.Join(tempDir, "realetc"), 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(buffer.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = tempDir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	fileContents := func(name, contents string) {
 		b, err := ioutil.ReadFile(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, string(b), contents)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, string(b), contents)
 	}
 
 	fileSymlinks := func(name, link string) {
 		l, err := os.Readlink(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, l, link)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, l, link)
 	}
 
 	fileExists("./pkg/foo")
@@ -171,8 +171,8 @@ func TestUntarExtractFollowingSymlinks(t *testing.T) {
 }
 
 func TestUntarCreatesDeeperPathsIfNotMentioned(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -188,10 +188,10 @@ func TestUntarCreatesDeeperPathsIfNotMentioned(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Size = int64(len(b))
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	// generate the mock tar... this will write to a file in a directory that
@@ -200,26 +200,26 @@ func TestUntarCreatesDeeperPathsIfNotMentioned(t *testing.T) {
 	archive.Close()
 
 	// create temp folder to extract to
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 	extractionPath := path.Join(tempDir, "pkg")
 	err := os.MkdirAll(extractionPath, 0755)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 
 	// extract
 	r := bytes.NewReader(buffer.Bytes())
 	u := NewUntar(r, extractionPath)
 	u.AbsoluteRoot = tempDir
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	fileContents := func(name, contents string) {
 		b, err := ioutil.ReadFile(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, string(b), contents)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, string(b), contents)
 	}
 
 	fileExists("./pkg/a_directory/file")
@@ -227,8 +227,8 @@ func TestUntarCreatesDeeperPathsIfNotMentioned(t *testing.T) {
 }
 
 func TestUntarExtractOverwriting(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -241,7 +241,7 @@ func TestUntarExtractOverwriting(t *testing.T) {
 		header.Mode = 0755
 		header.Mode |= c_ISDIR
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	writeFile := func(name, contents string) {
@@ -254,10 +254,10 @@ func TestUntarExtractOverwriting(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Size = int64(len(b))
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	writeSymlink := func(name, link string) {
@@ -268,27 +268,27 @@ func TestUntarExtractOverwriting(t *testing.T) {
 		header.Mode = 0644
 		header.Mode |= c_ISLNK
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	// create temp folder to extract to
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	fileContents := func(name, contents string) {
 		b, err := ioutil.ReadFile(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, string(b), contents)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, string(b), contents)
 	}
 
 	fileSymlinks := func(name, link string) {
 		l, err := os.Readlink(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
-		TestEqual(t, l, link)
+		tt.TestExpectSuccess(t, err)
+		tt.TestEqual(t, l, link)
 	}
 
 	// generate the mock tar
@@ -306,7 +306,7 @@ func TestUntarExtractOverwriting(t *testing.T) {
 	// extract
 	r := bytes.NewReader(buffer.Bytes())
 	u := NewUntar(r, tempDir)
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	// validate the first tar
 	fileExists("./foo")
@@ -340,7 +340,7 @@ func TestUntarExtractOverwriting(t *testing.T) {
 	// extract the 2nd tar
 	r = bytes.NewReader(buffer2.Bytes())
 	u = NewUntar(r, tempDir)
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	// verify the contents were overwritten as expected
 	fileContents("./foo", "bar")
@@ -351,8 +351,8 @@ func TestUntarExtractOverwriting(t *testing.T) {
 }
 
 func TestUntarIDMappings(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -367,7 +367,7 @@ func TestUntarIDMappings(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Uid = uid
 		header.Gid = gid
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	writeFileWithOwners := func(name, contents string, uid, gid int) {
@@ -382,10 +382,10 @@ func TestUntarIDMappings(t *testing.T) {
 		header.Uid = uid
 		header.Gid = gid
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	writeDirectoryWithOwners(".", 0, 0)
@@ -394,70 +394,70 @@ func TestUntarIDMappings(t *testing.T) {
 
 	// setup our mapping func
 	usr, err := user.Current()
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 	myUid, err := strconv.Atoi(usr.Uid)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 	myGid, err := strconv.Atoi(usr.Gid)
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 	uidFuncCalled := false
 	gidFuncCalled := false
 	uidMappingFunc := func(uid int) (int, error) {
 		uidFuncCalled = true
-		TestEqual(t, uid, 0)
+		tt.TestEqual(t, uid, 0)
 		return myUid, nil
 	}
 	gidMappingFunc := func(gid int) (int, error) {
 		gidFuncCalled = true
-		TestEqual(t, gid, 0)
+		tt.TestEqual(t, gid, 0)
 		return myGid, nil
 	}
 
 	// extract
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 	r := bytes.NewReader(buffer.Bytes())
 	u := NewUntar(r, tempDir)
 	u.PreserveOwners = true
 	u.OwnerMappingFunc = uidMappingFunc
 	u.GroupMappingFunc = gidMappingFunc
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	// verify it was called
-	TestEqual(t, uidFuncCalled, true)
-	TestEqual(t, gidFuncCalled, true)
+	tt.TestEqual(t, uidFuncCalled, true)
+	tt.TestEqual(t, gidFuncCalled, true)
 
 	// verify the file
 	stat, err := os.Stat(path.Join(tempDir, "foo"))
-	TestExpectSuccess(t, err)
+	tt.TestExpectSuccess(t, err)
 	sys := stat.Sys().(*syscall.Stat_t)
-	TestEqual(t, sys.Uid, uint32(myUid))
-	TestEqual(t, sys.Gid, uint32(myGid))
+	tt.TestEqual(t, sys.Uid, uint32(myUid))
+	tt.TestEqual(t, sys.Gid, uint32(myGid))
 }
 
 func TestUntarFailures(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// Bad compression type.
 	u := NewUntar(strings.NewReader("bad"), "/tmp")
 	u.Compression = Compression(-1)
-	TestExpectError(t, u.Extract())
+	tt.TestExpectError(t, u.Extract())
 
 	// FIXME(brady): add more cases here!
 }
 
 func TestCannotDetectCompression(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	u := NewUntar(strings.NewReader("bad"), "/tmp")
 	u.Compression = DETECT
 
-	TestExpectError(t, u.Extract())
+	tt.TestExpectError(t, u.Extract())
 }
 
 func TestUntarWhitelist(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -470,7 +470,7 @@ func TestUntarWhitelist(t *testing.T) {
 		header.Mode = 0755
 		header.Mode |= c_ISDIR
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	writeFile := func(name, contents string) {
@@ -483,10 +483,10 @@ func TestUntarWhitelist(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Size = int64(len(b))
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	writeDirectory(".")
@@ -508,7 +508,7 @@ func TestUntarWhitelist(t *testing.T) {
 	archive.Close()
 
 	// create temp folder to extract to
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 
 	// extract
 	r := bytes.NewReader(buffer.Bytes())
@@ -518,16 +518,16 @@ func TestUntarWhitelist(t *testing.T) {
 		"/usr/bin/",
 		"/usr/justdir",
 	}
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	fileNotExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectError(t, err)
+		tt.TestExpectError(t, err)
 	}
 
 	fileExists("/foo")
@@ -542,8 +542,8 @@ func TestUntarWhitelist(t *testing.T) {
 }
 
 func TestUntarCustomHandler(t *testing.T) {
-	StartTest(t)
-	defer FinishTest(t)
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
 
 	// create a buffer and tar.Writer
 	buffer := bytes.NewBufferString("")
@@ -556,7 +556,7 @@ func TestUntarCustomHandler(t *testing.T) {
 		header.Mode = 0755
 		header.Mode |= c_ISDIR
 		header.ModTime = time.Now()
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 	}
 
 	writeFile := func(name, contents string) {
@@ -569,10 +569,10 @@ func TestUntarCustomHandler(t *testing.T) {
 		header.ModTime = time.Now()
 		header.Size = int64(len(b))
 
-		TestExpectSuccess(t, archive.WriteHeader(header))
+		tt.TestExpectSuccess(t, archive.WriteHeader(header))
 		_, err := archive.Write(b)
-		TestExpectSuccess(t, err)
-		TestExpectSuccess(t, archive.Flush())
+		tt.TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, archive.Flush())
 	}
 
 	writeDirectory(".")
@@ -582,7 +582,7 @@ func TestUntarCustomHandler(t *testing.T) {
 	archive.Close()
 
 	// create temp folder to extract to
-	tempDir := TempDir(t)
+	tempDir := testHelper.TempDir()
 
 	// extract
 	r := bytes.NewReader(buffer.Bytes())
@@ -604,16 +604,16 @@ func TestUntarCustomHandler(t *testing.T) {
 			return true, nil
 		},
 	}
-	TestExpectSuccess(t, u.Extract())
+	tt.TestExpectSuccess(t, u.Extract())
 
 	fileExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectSuccess(t, err)
+		tt.TestExpectSuccess(t, err)
 	}
 
 	fileNotExists := func(name string) {
 		_, err := os.Stat(path.Join(tempDir, name))
-		TestExpectError(t, err)
+		tt.TestExpectError(t, err)
 	}
 
 	fileExists("/foo")

--- a/testtool/equal.go
+++ b/testtool/equal.go
@@ -7,22 +7,14 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 )
+
+var typeTime = reflect.TypeOf(time.Now())
 
 // -----------------------------------------------------------------------
 // Equality tests.
 // -----------------------------------------------------------------------
-
-// This describes the given object and if the output is too long then it
-// suppresses it unless --debug was used.
-func describe(prefix string, i interface{}) string {
-	out := fmt.Sprintf("%s%#v", prefix, i)
-	if len(out) > 160 && !TestDebug {
-		out = fmt.Sprintf(
-			"%s: Value suppressed. Use --debug to see it.", prefix)
-	}
-	return out
-}
 
 // Returns true if the value is nil. Interfaces can actually NOT be nil since
 // they have a type attached to them, even if the interface value is nil so
@@ -70,6 +62,12 @@ func TestMatch(t Logger, have string, r *regexp.Regexp) {
 	}
 }
 
+func TestNotMatch(t Logger, have string, r *regexp.Regexp) {
+	if r.MatchString(have) {
+		Fatalf(t, "Expected %s to not match regexp %v.", have, r)
+	}
+}
+
 func TestEqual(t Logger, have, want interface{}, msg ...string) {
 	haveNil := isNil(have)
 	wantNil := isNil(want)
@@ -109,7 +107,7 @@ func TestNotEqual(t Logger, have, want interface{}, msg ...string) {
 	r := deepValueEqual("", haveValue, wantValue, make(map[uintptr]*visit))
 	if len(r) == 0 {
 		Fatalf(t,
-			"Equality not expected%s\n%s", reason, describe("have: ", have))
+			"Equality not expected%s\nhave: %#v", reason, have)
 	}
 }
 
@@ -136,14 +134,21 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 	} else if !want.IsValid() && have.IsValid() {
 		// This is rare, not sure how to document this better.
 		return []string{
-			fmt.Sprintf("%s: have invalid object.", description),
+			fmt.Sprintf("%s: wanted an invalid object", description),
+			fmt.Sprintf(" have: %#v", have),
+			fmt.Sprintf(" want: %#v", want),
 		}
 	} else if want.IsValid() && !have.IsValid() {
 		// This is rare, not sure how to document this better.
 		return []string{
-			fmt.Sprintf("%s: wanted a valid object.", description),
+			fmt.Sprintf("%s: wanted an valid object", description),
+			fmt.Sprintf(" have: %#v", have),
+			fmt.Sprintf(" want: %#v", want),
 		}
-	} else if want.Type() != have.Type() {
+	}
+
+	wantType := want.Type()
+	if wantType != have.Type() {
 		return []string{fmt.Sprintf(
 			"%s: Not the same type, have: '%s', want: '%s'",
 			description, have.Type(), want.Type())}
@@ -165,28 +170,27 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 		// ... or already seen
 		h := 17*addr1 + addr2
 		seen := visited[h]
-		typ := want.Type()
 		for p := seen; p != nil; p = p.next {
-			if p.a1 == addr1 && p.a2 == addr2 && p.typ == typ {
+			if p.a1 == addr1 && p.a2 == addr2 && p.typ == wantType {
 				return []string{}
 			}
 		}
 
 		// Remember for later.
-		visited[h] = &visit{addr1, addr2, typ, seen}
+		visited[h] = &visit{addr1, addr2, wantType, seen}
 	}
 
 	// Checks to see if one value is nil, while the other is not.
 	checkNil := func() bool {
 		if want.IsNil() && !have.IsNil() {
 			diffs = append(diffs, fmt.Sprintf("%s: not equal.", description))
-			diffs = append(diffs, describe("have: ", have.Interface()))
-			diffs = append(diffs, "want: nil")
+			diffs = append(diffs, fmt.Sprintf(" have: %#v", have))
+			diffs = append(diffs, " want: nil")
 			return true
 		} else if !want.IsNil() && have.IsNil() {
 			diffs = append(diffs, fmt.Sprintf("%s: not equal.", description))
-			diffs = append(diffs, "have: nil")
-			diffs = append(diffs, describe("want: ", have.Interface()))
+			diffs = append(diffs, " have: nil")
+			diffs = append(diffs, fmt.Sprintf(" want: %#v", want))
 			return true
 		}
 		return false
@@ -198,8 +202,8 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 			diffs = append(diffs, fmt.Sprintf(
 				"%s: (len(have): %d, len(want): %d)",
 				description, have.Len(), want.Len()))
-			diffs = append(diffs, describe("have: ", have.Interface()))
-			diffs = append(diffs, describe("want: ", want.Interface()))
+			diffs = append(diffs, fmt.Sprintf(" have: %#v", have.Interface()))
+			diffs = append(diffs, fmt.Sprintf(" want: %#v", want.Interface()))
 			return true
 		}
 		return false
@@ -215,7 +219,6 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 				diffs = append(diffs, newdiffs...)
 			}
 		}
-
 	case reflect.Slice:
 		if !checkNil() && !checkLen() {
 			for i := 0; i < want.Len(); i++ {
@@ -225,39 +228,34 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 				diffs = append(diffs, newdiffs...)
 			}
 		}
-
 	case reflect.Interface:
 		if !checkNil() {
 			newdiffs := deepValueEqual(description, have.Elem(), want.Elem(), visited)
 			diffs = append(diffs, newdiffs...)
 		}
-
 	case reflect.Ptr:
 		newdiffs := deepValueEqual(description, have.Elem(), want.Elem(), visited)
 		diffs = append(diffs, newdiffs...)
-
 	case reflect.Struct:
+		// Custom time comparison to simulate time.Equal rather than DeepEqual.
+		if wantType == typeTime {
+			return timesEqual(description, have, want)
+		}
 		for i, n := 0, want.NumField(); i < n; i++ {
-			f := want.Type().Field(i)
-			if len(f.PkgPath) != 0 {
-				// skip unexported fields
-				continue
-			}
-			name := f.Name
+			f := wantType.Field(i)
 			// Make sure that we don't print a strange error if the
 			// first object given to us is a struct.
 			if description == "" {
 				newdiffs := deepValueEqual(
-					name, have.Field(i), want.Field(i), visited)
+					f.Name, have.Field(i), want.Field(i), visited)
 				diffs = append(diffs, newdiffs...)
 			} else {
 				newdiffs := deepValueEqual(
-					fmt.Sprintf("%s.%s", description, name),
+					fmt.Sprintf("%s.%s", description, f.Name),
 					have.Field(i), want.Field(i), visited)
 				diffs = append(diffs, newdiffs...)
 			}
 		}
-
 	case reflect.Map:
 		if !checkNil() {
 			// Check that the keys are present in both maps.
@@ -266,9 +264,9 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 					// Add the error.
 					diffs = append(diffs, fmt.Sprintf(
 						"%sExpected key [%q] is missing.", description, k))
-					diffs = append(diffs, "have: not present")
+					diffs = append(diffs, " have: not present")
 					diffs = append(diffs,
-						describe("want: ", want.MapIndex(k).Interface()))
+						fmt.Sprintf(" want: %#v", want.MapIndex(k).Interface()))
 					continue
 				}
 				newdiffs := deepValueEqual(
@@ -280,16 +278,15 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 				if !want.MapIndex(k).IsValid() {
 					// Add the error.
 					diffs = append(diffs, fmt.Sprintf("%sUnexpected key [%q].", description, k))
-					diffs = append(diffs, describe("have: ", have.MapIndex(k).Interface()))
-					diffs = append(diffs, "want: not present")
+					diffs = append(diffs, fmt.Sprintf(" have: %#v", have.MapIndex(k).Interface()))
+					diffs = append(diffs, " want: not present")
 				}
 			}
 		}
-
 	case reflect.Func:
-		// Can't do better than this:
+		// Can't do better than this; the Types are the same so the method
+		// signatures match.
 		checkNil()
-
 	case reflect.String:
 		// We know the underlying type is a string so calling String()
 		// will return the underlying value. Trying to call Interface()
@@ -301,8 +298,8 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 				fmt.Sprintf(
 					"%s: len(have) %d != len(want) %d.",
 					description, len(s1), len(s2)),
-				describe("have: ", s1),
-				describe("want: ", s2),
+				fmt.Sprintf(" have: %#v", s1),
+				fmt.Sprintf(" want: %#v", s2),
 			}
 		}
 		for i := range s1 {
@@ -311,111 +308,90 @@ func deepValueEqual(description string, have, want reflect.Value, visited map[ui
 					fmt.Sprintf(
 						"%s: difference at index %d.",
 						description, i),
-					describe("have: ", s1),
-					describe("want: ", s2),
+					fmt.Sprintf(" have: %#v", s1),
+					fmt.Sprintf(" want: %#v", s2),
 				}
 			}
 		}
-
+	case reflect.Bool:
+		v1, v2 := have.Bool(), want.Bool()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %v, want %v", description, v1, v2)}
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v1, v2 := have.Int(), want.Int()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %v, want %v", description, v1, v2)}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v1, v2 := have.Uint(), want.Uint()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %d, want %d", description, v1, v2)}
+		}
+	case reflect.Uintptr:
+		v1, v2 := have.Uint(), want.Uint()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %#x, want %#x", description, v1, v2)}
+		}
+	case reflect.Float32, reflect.Float64:
+		v1, v2 := have.Float(), want.Float()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %v, want %v", description, v1, v2)}
+		}
+	case reflect.Complex64, reflect.Complex128:
+		v1, v2 := have.Complex(), want.Complex()
+		if v1 != v2 {
+			return []string{fmt.Sprintf("%s: have %v, want %v", description, v1, v2)}
+		}
 	default:
-		// Specific low level types:
-		switch want.Interface().(type) {
-		case bool:
-			s1 := have.Interface().(bool)
-			s2 := want.Interface().(bool)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %t, want %t", description, s1, s2)}
-			}
-		case int:
-			s1 := have.Interface().(int)
-			s2 := want.Interface().(int)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case int8:
-			s1 := have.Interface().(int8)
-			s2 := want.Interface().(int8)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case int16:
-			s1 := have.Interface().(int16)
-			s2 := want.Interface().(int16)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case int32:
-			s1 := have.Interface().(int32)
-			s2 := want.Interface().(int32)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case int64:
-			s1 := have.Interface().(int64)
-			s2 := want.Interface().(int64)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uint:
-			s1 := have.Interface().(uint)
-			s2 := want.Interface().(uint)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uint8:
-			s1 := have.Interface().(uint8)
-			s2 := want.Interface().(uint8)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uint16:
-			s1 := have.Interface().(uint16)
-			s2 := want.Interface().(uint16)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uint32:
-			s1 := have.Interface().(uint32)
-			s2 := want.Interface().(uint32)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uint64:
-			s1 := have.Interface().(uint64)
-			s2 := want.Interface().(uint64)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case uintptr:
-			s1 := have.Interface().(uintptr)
-			s2 := want.Interface().(uintptr)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %d, want %d", description, s1, s2)}
-			}
-		case float32:
-			s1 := have.Interface().(float32)
-			s2 := want.Interface().(float32)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %f, want %f", description, s1, s2)}
-			}
-		case float64:
-			s1 := have.Interface().(float64)
-			s2 := want.Interface().(float64)
-			if s1 != s2 {
-				return []string{fmt.Sprintf("%s: have %f, want %f", description, s1, s2)}
-			}
-		default:
-			// Normal equality suffices
-			if !reflect.DeepEqual(want.Interface(), have.Interface()) {
-				return []string{
-					fmt.Sprintf("%s: not equal.", description),
-					describe("have: ", have),
-					describe("want: ", want),
-				}
-			}
+		// Chan, UnsafePointer, Invalid.
+		if !reflect.DeepEqual(have, want) {
+			return []string{fmt.Sprintf("%s: have %v, want %v", description, have, want)}
 		}
 	}
 
-	// This shouldn't ever be reached.
+	return diffs
+}
+
+// timesEqual simulates using time.Equal() rather than reflect.DeepEqual so that
+// moments in time are compared rather than including locations which only add
+// information for presentation.
+func timesEqual(description string, have, want reflect.Value) (diffs []string) {
+	// Special case when CanInterface is true. Recent change in fmt will call
+	// this before printing so we can't do the string comparison of the internal
+	// fields.
+	if have.CanInterface() {
+		t1, t2 := have.Interface().(time.Time), want.Interface().(time.Time)
+		if !t1.Equal(t2) {
+			return []string{"Not equal (using time.Equal):",
+				fmt.Sprintf(" have: %v", t1),
+				fmt.Sprintf(" want: %v", t2),
+			}
+		}
+		return
+	}
+
+	haveParts := strings.Split(strings.Trim(fmt.Sprintf("%v", have), "{}"), " ")
+	wantParts := strings.Split(strings.Trim(fmt.Sprintf("%v", want), "{}"), " ")
+	if len(haveParts) != len(wantParts) || len(haveParts) != 3 {
+		return []string{"Unexpected time.Time format; can't compare:",
+			fmt.Sprintf(" have: %#v", have),
+			fmt.Sprintf(" want: %#v", want),
+		}
+	}
+	if haveParts[0] != wantParts[0] {
+		diffs = append(diffs, []string{
+			fmt.Sprintf("%s: time.Time seconds not equal", description),
+			fmt.Sprintf(" have: %v", haveParts[0]),
+			fmt.Sprintf(" want: %v", wantParts[0]),
+		}...)
+	}
+	if haveParts[1] != wantParts[1] {
+		diffs = append(diffs, []string{
+			fmt.Sprintf("%s: time.Time nanoseconds not equal", description),
+			fmt.Sprintf(" have: %v", haveParts[1]),
+			fmt.Sprintf(" want: %v", wantParts[1]),
+		}...)
+	}
 	return diffs
 }

--- a/testtool/equal_test.go
+++ b/testtool/equal_test.go
@@ -3,13 +3,22 @@
 package testtool
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
+	"time"
 )
 
 type MyString string
+type foo struct{ aFooString string }
+type bar struct{ aBarString string }
+type fizz struct{ abuzz buzz }
+type buzz struct{ anInt, anInt2, anInt3 int }
+type timeFoo struct{ t time.Time }
 
 func TestTestEquals(t *testing.T) {
 	m := &MockLogger{}
+	m.funcFatalf = func(format string, i ...interface{}) { t.Logf(format, i...) }
 
 	var nilPtr *MockLogger
 	strSlice1 := []string{"A", "B", "C"}
@@ -18,6 +27,10 @@ func TestTestEquals(t *testing.T) {
 	strMap2 := map[string]int{"C": 3, "B": 2, "A": 1}
 	myStr1 := MyString("one")
 	myStr2 := MyString("one")
+	f := func(i int) string { return fmt.Sprint("f", i) }
+	g := func(i int) string { return fmt.Sprint("g", i) }
+	h := func(i int) int { return i }
+	t1 := time.Now()
 
 	// Non failure conditions.
 	m.RunTest(t, false, func() { TestEqual(m, nil, nil) })
@@ -39,11 +52,21 @@ func TestTestEquals(t *testing.T) {
 	m.RunTest(t, false, func() { TestEqual(m, strSlice1, strSlice2) })
 	m.RunTest(t, false, func() { TestEqual(m, strMap1, strMap2) })
 	m.RunTest(t, false, func() { TestEqual(m, myStr1, myStr2) })
+	m.RunTest(t, false, func() { TestEqual(m, fizz{buzz{1, 2, 3}}, fizz{buzz{1, 2, 3}}) })
+	m.RunTest(t, false, func() { TestEqual(m, &fizz{buzz{1, 2, 3}}, &fizz{buzz{1, 2, 3}}) })
+	m.RunTest(t, false, func() { TestEqual(m, f, f) })
+	m.RunTest(t, false, func() { TestEqual(m, f, g) })
+	m.RunTest(t, false, func() { TestEqual(m, t1, t1) })
+	m.RunTest(t, false, func() { TestEqual(m, t1, t1.UTC()) })
+	m.RunTest(t, false, func() { TestEqual(m, timeFoo{t1}, timeFoo{t1}) })
+	m.RunTest(t, false, func() { TestEqual(m, timeFoo{t1}, timeFoo{t1.UTC()}) })
 
 	// Expected failure conditions.
 	m.RunTest(t, true, func() { TestEqual(m, &MockLogger{}, nil) })
 	m.RunTest(t, true, func() { TestEqual(m, false, true) })
 	m.RunTest(t, true, func() { TestEqual(m, int(2), int(1)) })
+	m.RunTest(t, true, func() { TestEqual(m, int(1), int8(1)) })
+	m.RunTest(t, true, func() { TestEqual(m, int(1), "1") })
 	m.RunTest(t, true, func() { TestEqual(m, int8(2), int8(1)) })
 	m.RunTest(t, true, func() { TestEqual(m, int16(2), int16(1)) })
 	m.RunTest(t, true, func() { TestEqual(m, int32(2), int32(1)) })
@@ -56,6 +79,16 @@ func TestTestEquals(t *testing.T) {
 	m.RunTest(t, true, func() { TestEqual(m, float32(2), float32(1)) })
 	m.RunTest(t, true, func() { TestEqual(m, float64(2), float64(1)) })
 	m.RunTest(t, true, func() { TestEqual(m, "2", "1") })
+	m.RunTest(t, true, func() { TestEqual(m, fizz{buzz{1, 2, 3}}, fizz{buzz{1, 3, 3}}) })
+	m.RunTest(t, true, func() { TestEqual(m, &fizz{buzz{1, 2, 3}}, &fizz{buzz{1, 3, 3}}) })
+	m.RunTest(t, true, func() { TestEqual(m, fmt.Errorf("foo"), fmt.Errorf("bar")) })
+	m.RunTest(t, true, func() { TestEqual(m, bytes.NewBufferString("1"), bytes.NewBufferString("2")) })
+	m.RunTest(t, true, func() { TestEqual(m, f, nil) })
+	m.RunTest(t, true, func() { TestEqual(m, f, h) })
+	m.RunTest(t, true, func() { TestEqual(m, t1, t1.Add(time.Second*1)) })
+	m.RunTest(t, true, func() { TestEqual(m, t1, t1.Add(time.Microsecond*1)) })
+	m.RunTest(t, true, func() { TestEqual(m, timeFoo{t1}, timeFoo{t1.Add(time.Second * 1)}) })
+	m.RunTest(t, true, func() { TestEqual(m, timeFoo{t1}, timeFoo{t1.Add(time.Microsecond * 1)}) })
 
 	strSlice1[0] = "X"
 	strMap1["A"] = 3
@@ -71,8 +104,12 @@ func TestTestNotEquals(t *testing.T) {
 	strSlice2 := []string{"A", "B", "C"}
 	strMap1 := map[string]int{"A": 1, "B": 2, "C": 3}
 	strMap2 := map[string]int{"C": 3, "B": 2, "A": 1}
+	f := func(i int) string { return fmt.Sprint("f", i) }
+	g := func(i int) string { return fmt.Sprint("g", i) }
+	h := func(i int) int { return i }
+	t1 := time.Now()
 
-	// Non failure conditions.
+	// Expected failure conditions.
 	m.RunTest(t, true, func() { TestNotEqual(m, nil, nil) })
 	m.RunTest(t, true, func() { TestNotEqual(m, true, true) })
 	m.RunTest(t, true, func() { TestNotEqual(m, int(1), int(1)) })
@@ -91,11 +128,19 @@ func TestTestNotEquals(t *testing.T) {
 	m.RunTest(t, true, func() { TestNotEqual(m, nilPtr, nil) })
 	m.RunTest(t, true, func() { TestNotEqual(m, strSlice1, strSlice2) })
 	m.RunTest(t, true, func() { TestNotEqual(m, strMap1, strMap2) })
+	m.RunTest(t, true, func() { TestNotEqual(m, fizz{buzz{1, 2, 3}}, fizz{buzz{1, 2, 3}}) })
+	m.RunTest(t, true, func() { TestNotEqual(m, &fizz{buzz{1, 2, 3}}, &fizz{buzz{1, 2, 3}}) })
+	m.RunTest(t, true, func() { TestNotEqual(m, f, f) })
+	m.RunTest(t, true, func() { TestNotEqual(m, f, g) })
+	m.RunTest(t, true, func() { TestNotEqual(m, t1, t1) })
+	m.RunTest(t, true, func() { TestNotEqual(m, t1, t1.UTC()) })
 
-	// Expected failure conditions.
+	// Non-failure conditions.
 	m.RunTest(t, false, func() { TestNotEqual(m, &MockLogger{}, nil) })
 	m.RunTest(t, false, func() { TestNotEqual(m, false, true) })
 	m.RunTest(t, false, func() { TestNotEqual(m, int(2), int(1)) })
+	m.RunTest(t, false, func() { TestNotEqual(m, int(1), int8(1)) })
+	m.RunTest(t, false, func() { TestNotEqual(m, int(1), "1") })
 	m.RunTest(t, false, func() { TestNotEqual(m, int8(2), int8(1)) })
 	m.RunTest(t, false, func() { TestNotEqual(m, int16(2), int16(1)) })
 	m.RunTest(t, false, func() { TestNotEqual(m, int32(2), int32(1)) })
@@ -108,6 +153,15 @@ func TestTestNotEquals(t *testing.T) {
 	m.RunTest(t, false, func() { TestNotEqual(m, float32(2), float32(1)) })
 	m.RunTest(t, false, func() { TestNotEqual(m, float64(2), float64(1)) })
 	m.RunTest(t, false, func() { TestNotEqual(m, "2", "1") })
+	m.RunTest(t, false, func() { TestNotEqual(m, fizz{buzz{1, 2, 3}}, fizz{buzz{1, 3, 3}}) })
+	m.RunTest(t, false, func() { TestNotEqual(m, &fizz{buzz{1, 2, 3}}, &fizz{buzz{1, 3, 3}}) })
+	m.RunTest(t, false, func() { TestNotEqual(m, fmt.Errorf("foo"), fmt.Errorf("bar")) })
+	m.RunTest(t, false, func() { TestNotEqual(m, bytes.NewBufferString("1"), bytes.NewBufferString("2")) })
+	m.RunTest(t, false, func() { TestNotEqual(m, f, nil) })
+	m.RunTest(t, false, func() { TestNotEqual(m, f, h) })
+	m.RunTest(t, false, func() { TestNotEqual(m, []int{}, []int(nil)) })
+	m.RunTest(t, false, func() { TestNotEqual(m, t1, t1.Add(time.Second*1)) })
+	m.RunTest(t, false, func() { TestNotEqual(m, t1, t1.Add(time.Microsecond*1)) })
 
 	strSlice1[0] = "X"
 	strMap1["A"] = 3

--- a/testtool/gettestdata.go
+++ b/testtool/gettestdata.go
@@ -1,0 +1,47 @@
+package testtool
+
+import (
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type TestData struct {
+	File       string
+	Package    string
+	TestName   string
+	PackageDir string
+	Line       int
+}
+
+// GetTestData goes through the call stack of the current goroutine and creates
+// a ordered set of strings for the files, function names, and line numbers then
+// adds this data to the error message.
+func GetTestData(t *testing.T) *TestData {
+	var pcs [20]uintptr
+	pcCount := runtime.Callers(2, pcs[:])
+	pcCount -= 2
+
+	for _, pc := range pcs[0:pcCount] {
+		f := runtime.FuncForPC(pc)
+		file, line := f.FileLine(pc - 1)
+		basePkgDir, pkgFname := path.Split(f.Name())
+		fname := path.Ext(pkgFname)
+		pkg := strings.TrimSuffix(pkgFname, fname)
+		fname = strings.TrimLeft(fname, ".")
+		pkgDir := path.Join(basePkgDir, pkg)
+
+		if strings.HasPrefix(fname, "Test") {
+			return &TestData{
+				File:       file,
+				Line:       line,
+				TestName:   fname,
+				Package:    pkg,
+				PackageDir: pkgDir,
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
 - Previously we were skipping over unexported fields silently which
gives misleading results in many situations (e.g. two different
byte buffers with different contents would pass TestEqual). Included
many changes to how deepValueEquals iterates over values.

 - Added one more helper (TestNotMatch).

 - Updated method signatures to match expectations in our other codebase
including creating a TestTool object rather than relying only on global
state.

 - Misc readability fixes