### PR TITLE
testtool: Add more info when describing non-nil result

### DIFF
--- a/testtool/equal.go
+++ b/testtool/equal.go
@@ -80,7 +80,7 @@ func TestEqual(t Logger, have, want interface{}, msg ...string) {
 	} else if haveNil && !wantNil {
 		Fatalf(t, "%sExpected non nil, got nil.", reason)
 	} else if !haveNil && wantNil {
-		Fatalf(t, "%sExpected nil, got non nil.", reason)
+		Fatalf(t, "%sExpected nil, got non nil: %#v", reason, have)
 	}
 	haveValue := reflect.ValueOf(have)
 	wantValue := reflect.ValueOf(want)


### PR DESCRIPTION
When you expect nil but get non nil the current message does
not give enough information for debugging. It should describe
what you actually got.