### PR TITLE
tarhelper - Option to prefix or suffix files/headers in the archive.

### DIFF
--- a/tarhelper/tar_test.go
+++ b/tarhelper/tar_test.go
@@ -56,6 +56,27 @@ func TestTarSimple(t *testing.T) {
 	tt.TestExpectSuccess(t, tw.Archive())
 }
 
+func TestTarHooks(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	w := bytes.NewBufferString("")
+	tw := NewTar(w, makeTestDir(t))
+	prefixRan := false
+	suffixRan := false
+	tw.PrefixHook = func(archive *tar.Writer) error {
+		prefixRan = true
+		return nil
+	}
+	tw.SuffixHook = func(archive *tar.Writer) error {
+		suffixRan = true
+		return nil
+	}
+	tt.TestExpectSuccess(t, tw.Archive())
+	tt.TestTrue(t, prefixRan)
+	tt.TestTrue(t, suffixRan)
+}
+
 func TestTarVirtualPath(t *testing.T) {
 	testHelper := tt.StartTest(t)
 	defer testHelper.FinishTest()


### PR DESCRIPTION
CustomHandler[] callbacks can only modify the headers of existing files.  PrefixHook and SuffixHook add the ability to insert additional headers or file data into the archive. 

This will be used to insert the base whiteout file ( ./..wh.wh.aufs ) when tar'ing Overlayfs based layers into the AUFS format used in packages.  All other whiteout files are a hardlink of the base whiteout file.  